### PR TITLE
登録したクレジットカードを削除する機能追加

### DIFF
--- a/Controller/PaymentController.php
+++ b/Controller/PaymentController.php
@@ -167,7 +167,7 @@ class PaymentController extends AbstractShoppingController
                 $this->entityManager->flush();
                 logs('stripe')->info($intent->status);
 
-                if ($intent->status === "requires_action") {
+                if ("requires_action" === $intent->status) {
                     $intent->confirm([
                         'return_url' => $this->generateUrl('shopping_stripe_callback', [], UrlGeneratorInterface::ABSOLUTE_URL)
                     ]);

--- a/Controller/ShoppingController.php
+++ b/Controller/ShoppingController.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of Stripe4
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Stripe4\Controller;
+
+
+use Eccube\Common\EccubeConfig;
+use Eccube\Controller\AbstractController;
+use Eccube\Entity\Customer;
+use Stripe\PaymentMethod;
+use Stripe\Stripe;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * Class CreditCardController
+ * @package Plugin\Stripe4\Controller
+ *
+ * @Route("/shopping/creadit_card")
+ */
+class ShoppingController extends AbstractController
+{
+    public function __construct(EccubeConfig $eccubeConfig)
+    {
+        $this->eccubeConfig = $eccubeConfig;
+        Stripe::setApiKey($this->eccubeConfig['stripe_secret_key']);
+    }
+
+    /**
+     * @Route("/detach/{pm}", name="shopping_credit_card_detach")
+     */
+    public function detach(Request $request, $pm)
+    {
+        /** @var Customer $customer */
+        $customer = $this->getUser();
+
+        if (!$customer instanceof Customer) {
+            return $this->redirectToRoute('shopping_login');
+        }
+
+        $paymentMethod = PaymentMethod::retrieve($pm);
+        $paymentMethod->detach();
+
+        return $this->redirectToRoute('shopping');
+    }
+}

--- a/Resource/template/credit.twig
+++ b/Resource/template/credit.twig
@@ -27,7 +27,7 @@ Shopping/index.twigに追記
                             <div class="ec-radio">
                                 {% for card in form.cards %}
                                     <div style="display: block">
-                                        {{ form_widget(card) }}
+                                        {{ form_widget(card) }} <button class="btn btn-danger btn-xs" data-trigger="click" data-path="{{ path('shopping_credit_card_detach', {'pm': card.vars.value}) }}">削除</button>
                                     </div>
                                 {% endfor %}
                             </div>


### PR DESCRIPTION
ご注文手続きページで登録しているクレジットカードを削除する機能追加。

こちらの対応。

https://github.com/kurozumi/Stripe4/issues/22


マイページに登録クレジットカード一覧表示ページを作りたいが工数が多いため保留。

