### PR TITLE
support EC-CUBE4.2

### DIFF
--- a/Form/Extension/CreditCardExtension.php
+++ b/Form/Extension/CreditCardExtension.php
@@ -129,7 +129,7 @@ class CreditCardExtension extends AbstractTypeExtension
     /**
      * @return iterable
      */
-    public function getExtendedTypes(): iterable
+    public static function getExtendedTypes(): iterable
     {
         return [OrderType::class];
     }

--- a/Repository/ConfigRepository.php
+++ b/Repository/ConfigRepository.php
@@ -15,11 +15,11 @@ namespace Plugin\Stripe4\Repository;
 
 use Eccube\Repository\AbstractRepository;
 use Plugin\Stripe4\Entity\Config;
-use Symfony\Bridge\Doctrine\RegistryInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 class ConfigRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Config::class);
     }

--- a/Repository/PaymentStatusRepository.php
+++ b/Repository/PaymentStatusRepository.php
@@ -14,11 +14,10 @@ namespace Plugin\Stripe4\Repository;
 
 use Eccube\Repository\AbstractRepository;
 use Plugin\Stripe4\Entity\PaymentStatus;
-use Symfony\Bridge\Doctrine\RegistryInterface;
-
+use Doctrine\Persistence\ManagerRegistry;
 class PaymentStatusRepository extends AbstractRepository
 {
-    public function __construct(RegistryInterface $registry)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PaymentStatus::class);
     }


### PR DESCRIPTION
EC-CUBE 4.2 からSymfonyが5.4になった事でいくつか例外エラーが発生していたので修正しました。
https://doc4.ec-cube.net/update-41-42

ただ、これによって4.1以下の互換性が無くなるかもしれませんので新たに4.2というタグを作成した方が良いかもしれません…